### PR TITLE
Fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,12 @@ lorax/*
 lorax_results/*
 mock_result/*
 ISO/*
-*/efi
-*/OVMF_CODE.fd
-*/vm_vars.fd
+host-vm/efi
+host-vm/OVMF_CODE.fd
+host-vm/vm_vars.fd
 host-vm/eficonfig/NvmeOfCli.efi
-*/efi.tgz
-host-vm/copy_efi.sh
+host-vm/efi.tgz
 host-vm/discover_target.sh
+host-vm/copy_efi.sh
 host-vm/eficonfig/config
+host-vm/efidisk

--- a/README.md
+++ b/README.md
@@ -150,13 +150,22 @@ create a root account with ssh access*.
 
 | Fedora Install Step  | Action |
 | :-----               | :----      |
-| **Select Timezone**  | Click `Done` to Continue |
-| **This is unstable, pre-released software**  |  Click `I want to procced` |
-| **Installation Destination** | Click `Done` |
+| **Select Language**  | Click `Continue` |
+| **This is unstable, pre-release software**  |  Click `I want to procced` |
+| **Installation Destination** | The disk is pre-selected.  Simply Click `Done` |
 | **Root Account** | Click `Enable root account` |
-| enter password | - [x] Allow root SSH login with password |
+| enter Root Password | - [x] Allow root SSH login with password |
+| **User Creation** | *Optional: Create a user account if wanted. All POC configuration will use the root account.* |
 | final step | Click `Begin installation` |
-| finish install | Click `Reboot System`|
+| **INSTALLATION PROGRESS** | Click `Reboot System` when done|
+| Complete the installation | It is important to wait for the VM to cleanly reboot in order to complete the installation. |
+
+After the VM reboots login to the *root* account to be sure everything is
+working. The VM should now be reachable through `enp0s4` which is the DHCP
+controlled management network on the hypervisor's *br0* bridged network;
+`enp0s5` and `enp0s6` are statically configured and unconnected. Use the `ip
+-br addr show` and `nmcli dev status` commands to see if the networks are there
+and correctly working.
 
 ## The ./netsetup.sh script
 

--- a/host-vm/create_efidisk.sh
+++ b/host-vm/create_efidisk.sh
@@ -30,6 +30,9 @@ sed -i "s/HOSTGW_IP2/0.0.0.0/" eficonfig/config
 sed -i "s/TARGET_IP2/$TARGET_IP2/" eficonfig/config
 sed -i "s/SUBNQN/$SUBNQN/" eficonfig/config
 
+rm -f efidisk
+cp -v efidisk.in efidisk
+
 sudo losetup -D loop1
 sudo losetup -P loop1 $PWD/efidisk
 sudo mkfs.vfat /dev/loop1p1
@@ -37,7 +40,7 @@ sudo losetup -D loop1
 
 mkdir -p efi
 sudo mount -t vfat -o loop,offset=1048576 $PWD/efidisk $PWD/efi
-df efi
+#df efi
 sudo tar xzvf efi.tgz
 sudo cp -v $PWD/eficonfig/config $PWD/efi/EFI/BOOT
 sudo cp -v $PWD/eficonfig/startup.nsh $PWD/efi/EFI/BOOT
@@ -46,5 +49,6 @@ sudo umount $PWD/efi
 rmdir efi
 
 echo ""
-echo " Next step will be to the to install and configure the target-vm"
+echo " Next step is to install and configure the target-vm"
+echo " with \"cd ../target-vm; ./install.sh\""
 echo ""

--- a/host-vm/install.sh
+++ b/host-vm/install.sh
@@ -17,7 +17,7 @@ create_install_startup() {
     rm -rf .build
     mkdir .build
 
-	echo " creating .build/install.sh"
+	echo "creating .build/install.sh"
 	cat << EOF >> .build/install.sh
 #!/bin/bash
 $QEMU -name $VMNAME -M q35 -accel kvm -cpu host -m 4G -smp 4 $QARGS \
@@ -34,7 +34,7 @@ $QEMU -name $VMNAME -M q35 -accel kvm -cpu host -m 4G -smp 4 $QARGS \
 -netdev bridge,br=virbr2,id=net2,helper=$BRIDGE \
 -device virtio-net-pci,netdev=net2,mac=$MAC3 
 EOF
-	echo " creating .build/start.sh"
+	echo "creating .build/start.sh"
 	cat << EOF >> .build/start.sh
 #!/bin/bash
 $QEMU -name $VMNAME -M q35 -accel kvm -cpu host -m 4G -smp 4 $QARGS \
@@ -58,7 +58,7 @@ check_host_install_args $# "$1"
 ISO_FILE=$(find ../ -name boot.iso -print)
 if [ -z "$ISO_FILE" ]; then
 	echo " Error: lorax_results/images/boot.iso not found"
-	echo " run setup.sh iso"
+	echo " run setup.sh -m iso"
 	exit 1
 else
     ISO_FILE=$(realpath $ISO_FILE)

--- a/host-vm/netsetup.sh
+++ b/host-vm/netsetup.sh
@@ -36,8 +36,8 @@ echo " scp the efi.tgz file to the hypervisor host"
 scp -o StrictHostKeyChecking=no efi.tgz $TESTUSR@host-gw:$HOSTEFIDIR/efi.tgz
 
 echo ""
-echo " Please shutdown this VM and run the \"./create_efidisk.sh\" script."
-#echo " Please shutdown this VM and run the \"target-vm/start.sh\" script."
+echo " Shutdown this VM and run the \"./create_efidisk.sh\" script on the hypervisor."
+echo " Then run the \"target-vm/install.sh\" script to create the target-vm."
 echo ""
 
 EOF

--- a/host-vm/netsetup.sh
+++ b/host-vm/netsetup.sh
@@ -92,6 +92,7 @@ rm -rf efi efi.tgz
 echo ""
 echo " scp  .build/{netsetup.sh,hosts.txt} root@$3:"
 echo ""
+ssh-keygen -R $3
 scp -o StrictHostKeyChecking=no .build/{netsetup.sh,hosts.txt} root@$3:
 
 echo ""

--- a/host-vm/start.sh
+++ b/host-vm/start.sh
@@ -28,15 +28,11 @@ if [  -f .qargs ]; then
     echo ""
 fi
 
-#if [ ! -f .start ]; then
-#    echo ""
-#    echo " Log into the root account and record the interface names for networks 2 and 3."
-#    echo " Use the \"ip -br address show\" command to display interface names"
-#    echo ""
-#    echo " Next step will be to run the \"./netsetup.sh\" script."
-#    echo ""
-#fi
-
-#touch .start
+echo ""
+echo " Connect to the `host-vm` console and immediately Press the ESC button to enter the UEFI setup menu."
+echo " - Change the device boot order so the EFI Internal Shell starts first. Exit to continue."
+echo " - The UEFI Shell will execute the startup script, let the countdown expire."
+echo " - Then Reset to reboot the VM. The UEFI will connect to the NVMe/TCP target and boot."
+echo ""
 
 bash .build/start.sh &

--- a/setup.sh
+++ b/setup.sh
@@ -97,11 +97,6 @@ install_user() {
             create_copr_project
         fi
 
-       # Use this to ignore the efidisk
-       # WARNING: changing the efidisk can cause the host-vm to fail
-       
-       # git update-index --assume-unchanged host-vm/efidisk
-
         touch .usr
     fi
 

--- a/target-vm/netsetup.sh
+++ b/target-vm/netsetup.sh
@@ -42,7 +42,8 @@ echo "$TARGETNQN" > /etc/nvme/hostnqn
 echo "$TARGETID" > /etc/nvme/hostid
 
 echo ""
-echo " Shutdown and run \"host-vm/install.sh\" to complete the host"
+echo " Run \"./start-tcp-target.sh\" to start the NVMe/TCP soft target."
+echo " Then run \"host-vm/start.sh\" on the hypervisor to boot the host-vm with NVMe/TCP "
 echo ""
 
 EOF

--- a/target-vm/netsetup.sh
+++ b/target-vm/netsetup.sh
@@ -79,6 +79,7 @@ chmod 755 .build/hosts.txt
 echo ""
 echo " scp  .build/{netsetup.sh,start-tcp-target.sh,hosts.txt,tcp.json} root@$3:"
 echo ""
+ssh-keygen -R $3
 scp -o StrictHostKeyChecking=no .build/{netsetup.sh,hosts.txt,start-tcp-target.sh,tcp.json} root@$3:
 
 echo ""


### PR DESCRIPTION
vm: get rid of those pesky ssh warnings during install
vm: fix the scripted install instructions
readme: update the Fedora install instructions
setup: remove the assumptions about efidisk in setup
host-vm: ignore the artifacts in host-vm
host-vm: change the way we manage the efidisk
host-vm: move the efidisk in prep of rework
