### PR TITLE
Fix sys UUID

### DIFF
--- a/global_vars.sh
+++ b/global_vars.sh
@@ -7,17 +7,21 @@
 COPR_PROJECT=timberland-sig
 COPR_USER=johnmeneghini
 
-# These are the Hostnqn and Hostid for the target-vm
+# These are the system-uuid, Hostnqn and Hostid for the target-vm
 TARGETID="e1df2843-7f74-48c4-adb0-b2a5b9bab8f1"
-TARGETNQN="nqn.2014-08.org.nvmexpress:uuid:a53caec2-eb2d-4bca-819e-f2bbfb10e1fa"
+# The TARGET_SYS_UUID is generated with TARGET_SYS_UUID="$(uuidgen)"
+TARGET_SYS_UUID="a53caec2-eb2d-4bca-819e-f2bbfb10e1fa"
+TARGETNQN="nqn.2014-08.org.nvmexpress:uuid:$TARGET_SYS_UUID"
 
-# These are the Hostnqn and Hostid for the host-vm
+# These are the system-uuid, Hostnqn and Hostid for the host-vm
 HOSTID="4e16bbb4-097f-44be-8c7f-77d8b4fc9f39"
+# This HostNQN appears in the target-vm/tcp.json file and in the host-vm/discover_target.sh file
+# The HOST_SYS_UUID is generated with HOST_SYS_UUID="$(uuidgen)"
+HOST_SYS_UUID="f8131bac-cdef-4165-866b-5998c1e67890"
+HOSTNQN="nqn.2014-08.org.nvmexpress:uuid:$HOST_SYS_UUID"
 
-# This HostNQN appears in the tcp.json file and in the host-vm/discover_target.sh file
-HOSTNQN="nqn.2014-08.org.nvmexpress:uuid:f8131bac-cdef-4165-866b-5998c1e67890"
-
-# This is the Subsystem NQN for the tcp.json file
+# These are the Namespace identifiers and Subsystem NQN for the Linux Ctrl soft target.
+# See the target-vm/tcp.json.in file for more information.
 SUBNQN="nqn.2014-08.org.nvmexpress:uuid:0c468c4d-a385-47e0-8299-6e95051277db"
 NSNGUID="ace42e00-1510-2fce-2ee4-ac0000000001"
 NSUUID="bee9c2b7-1761-44b5-a4e6-0f690498a94b"

--- a/host-vm/install.sh
+++ b/host-vm/install.sh
@@ -17,8 +17,8 @@ create_install_startup() {
     rm -rf .build
     mkdir .build
 
-	echo "creating .build/install.sh"
-	cat << EOF >> .build/install.sh
+    echo "creating .build/install.sh"
+    cat << EOF >> .build/install.sh
 #!/bin/bash
 $QEMU -name $VMNAME -M q35 -accel kvm -cpu host -m 4G -smp 4 $QARGS \
 -cdrom $ISO_FILE \

--- a/host-vm/install.sh
+++ b/host-vm/install.sh
@@ -21,6 +21,7 @@ create_install_startup() {
     cat << EOF >> .build/install.sh
 #!/bin/bash
 $QEMU -name $VMNAME -M q35 -accel kvm -cpu host -m 4G -smp 4 $QARGS \
+-uuid $HOST_SYS_UUID \
 -cdrom $ISO_FILE \
 -device nvme,drive=NVME2,max_ioqpairs=4,physical_block_size=4096,logical_block_size=4096,use-intel-id=on,serial=$SN2 \
 -drive file=$BOOT_DISK,if=none,id=NVME2 \
@@ -38,6 +39,7 @@ EOF
 	cat << EOF >> .build/start.sh
 #!/bin/bash
 $QEMU -name $VMNAME -M q35 -accel kvm -cpu host -m 4G -smp 4 $QARGS \
+-uuid $HOST_SYS_UUID \
 -device virtio-rng -boot menu=on,splash-time=2000 \
 -drive if=pflash,format=raw,readonly=on,file=OVMF_CODE.fd \
 -drive if=pflash,format=raw,file=vm_vars.fd \

--- a/host-vm/netsetup.sh
+++ b/host-vm/netsetup.sh
@@ -44,8 +44,7 @@ EOF
 }
 
 create_copy_efi() {
-    rm -f efi.tgz
-
+    rm -f copy_efi.sh
     cat << EOF >> copy_efi.sh
 #!/bin/bash
 rm -f efi.tgz
@@ -62,6 +61,7 @@ EOF
 }
 
 create_discover_target() {
+    rm -f discover_target.sh
     cat << EOF >> discover_target.sh
 #!/bin/bash
 sudo modprobe nvme_fabrics

--- a/host-vm/netsetup.sh
+++ b/host-vm/netsetup.sh
@@ -19,7 +19,6 @@ dnf install -y git tar vim nvme-cli
 dnf update -y dracut
 dnf install -y dracut-network
 
-echo "$HOSTNQN" > /etc/nvme/hostnqn
 echo "$HOSTID" > /etc/nvme/hostid
 
 modprobe nvme_fabrics

--- a/host-vm/start.sh
+++ b/host-vm/start.sh
@@ -29,7 +29,7 @@ if [  -f .qargs ]; then
 fi
 
 echo ""
-echo " Connect to the `host-vm` console and immediately Press the ESC button to enter the UEFI setup menu."
+echo " Connect to the \"host-vm\" console and immediately Press the ESC button to enter the UEFI setup menu."
 echo " - Change the device boot order so the EFI Internal Shell starts first. Exit to continue."
 echo " - The UEFI Shell will execute the startup script, let the countdown expire."
 echo " - Then Reset to reboot the VM. The UEFI will connect to the NVMe/TCP target and boot."

--- a/target-vm/install.sh
+++ b/target-vm/install.sh
@@ -20,6 +20,7 @@ create_install_startup() {
 	cat << EOF >> .build/install.sh
 #!/bin/bash
 $QEMU -name $VMNAME -M q35 -accel kvm -bios OVMF-pure-efi.fd -cpu host -m 4G -smp 4 $QARGS \
+-uuid $TARGET_SYS_UUID \
 -cdrom $ISO_FILE \
 -device nvme,drive=NVME1,max_ioqpairs=4,physical_block_size=4096,logical_block_size=4096,use-intel-id=on,serial=$SN1 \
 -drive file=disks/boot.qcow2,if=none,id=NVME1 \
@@ -30,6 +31,7 @@ EOF
 	cat << EOF >> .build/start.sh
 #!/bin/bash
 $QEMU -name $VMNAME -M q35 -accel kvm -bios OVMF-pure-efi.fd -cpu host -m 4G -smp 4 -boot menu=on $QARGS \
+-uuid $TARGET_SYS_UUID \
 -device nvme,drive=NVME1,max_ioqpairs=4,physical_block_size=4096,logical_block_size=4096,use-intel-id=on,serial=$SN1,bootindex=1 \
 -drive file=disks/boot.qcow2,if=none,id=NVME1 \
 -device nvme,drive=NVME2,max_ioqpairs=4,physical_block_size=4096,logical_block_size=4096,use-intel-id=on,serial=$SN2 \

--- a/target-vm/netsetup.sh
+++ b/target-vm/netsetup.sh
@@ -11,6 +11,7 @@ VMNAME=`basename $PWD`
 
 create_nvme_target_config() {
     rm -f .build/tcp.json
+    rm -f .build/start-tcp-target.sh
 
     cp tcp.json.in .build/tcp.json
 
@@ -36,7 +37,7 @@ add_target_netsetup() {
     cat << EOF >> .build/netsetup.sh
 
 dnf copr enable -y $COPR_USER/$COPR_PROJECT
-dnf install -y git tar vim nvme-cli nvmetcli
+dnf install -y nvme-cli nvmetcli
 
 echo "$TARGETNQN" > /etc/nvme/hostnqn
 echo "$TARGETID" > /etc/nvme/hostid
@@ -45,18 +46,6 @@ echo ""
 echo " Run \"./start-tcp-target.sh\" to start the NVMe/TCP soft target."
 echo " Then run \"host-vm/start.sh\" on the hypervisor to boot the host-vm with NVMe/TCP "
 echo ""
-
-EOF
-}
-
-add_target_netsetup() {
-    cat << EOF >> .build/netsetup.sh
-
-dnf copr enable -y $COPR_USER/$COPR_PROJECT
-dnf install -y git tar vim nvme-cli nvmetcli
-
-echo "$TARGETNQN" > /etc/nvme/hostnqn
-echo "$TARGETID" > /etc/nvme/hostid
 
 EOF
 }

--- a/target-vm/netsetup.sh
+++ b/target-vm/netsetup.sh
@@ -39,7 +39,6 @@ add_target_netsetup() {
 dnf copr enable -y $COPR_USER/$COPR_PROJECT
 dnf install -y nvme-cli nvmetcli
 
-echo "$TARGETNQN" > /etc/nvme/hostnqn
 echo "$TARGETID" > /etc/nvme/hostid
 
 echo ""


### PR DESCRIPTION
The nvme-cli gen-hostnqn utility uses the system-uuid reported in
`dmidecode -s system-uuid`. By default qemu leaves the system-uuid
unset. This causes hostnqn 00000000-0000-0000-0000-000000000000. To fix
this problem pass the -uuid option on the qemu command line.
    
On the guest vm see `cat /sys/class/dmi/id/product_uuid`
