### PR TITLE
Artifacts collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,13 +37,7 @@ mock_result/*
 mock_repo/*
 __pycache__/*
 ISO/*
-artifacts/NvmeOfCli.efi
-artifacts/OVMF_CODE.fd
-artifacts/OVMF_VARS.fd
-artifacts/VConfig.efi
-artifacts/checksum.sha256
-artifacts/timberland-ovmf.zip
-artifacts/top-commit.txt
+artifacts/*
 *-vm/.net
 host-vm/bootlog*
 host-vm/efi

--- a/iso_selector.py
+++ b/iso_selector.py
@@ -191,7 +191,7 @@ def main():
     selection = _tui_select()
     if selection is None:
         print("Cancelled.")
-        sys.exit(1)
+        sys.exit(0)
 
     label, resolver = CHOICES[selection]
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -16,6 +16,7 @@ import sys
 import time
 import socket
 import warnings
+import paramiko
 from pathlib import Path
 from typing import Dict, List, Any, Optional
 import pytest
@@ -683,6 +684,49 @@ class VMRunner:
         print(f"✗ Bootlog entry not found within {timeout}s")
         return False
 
+    def collect_artifacts(self, host_ip: str, nbft_out_file: Path, dmesg_out_file: Path) -> bool:
+        """SSH into the host-vm and collect intersting artifacts"""
+
+        ssh_key = SCRIPT_DIR / ".ssh" / "id_ecdsa"
+        print("Collecting artifacts from host-vm...")
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+            client.connect(
+                host_ip,
+                username='root',
+                key_filename=str(ssh_key),
+                timeout=5,
+            )
+
+            self.collect_ssh_artifact("NBFT", "nvme nbft show --output-format=json", client, nbft_out_file)
+            self.collect_ssh_artifact("dmesg", "dmesg", client, dmesg_out_file)
+            return True
+        except Exception as e:
+            print(f"✗ Artifacts collection failed: {e}")
+            return False
+        finally:
+            client.close()
+
+    def collect_ssh_artifact(self, name: str, command: str, ssh_client, output_file: Path) -> None:
+        """SSH into the host-vm and export the output of a command."""
+
+        _, stdout, stderr = ssh_client.exec_command(command, timeout=10)
+        exit_status = stdout.channel.recv_exit_status()
+
+        if exit_status != 0:
+            err = stderr.read().decode().strip()
+            print(f"✗ '{command}' failed (exit code: {exit_status})")
+            if err:
+                print(f"  {err}")
+            return
+
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_file, 'w') as f:
+            f.write(stdout.read().decode())
+
+        print(f"✓ {name} saved to {output_file}")
+
     def cleanup(self):
         """Kill the VM using make kill."""
         print("Cleaning up VM...")
@@ -798,6 +842,10 @@ class TestNVMeBoot:
         efi_gen = EFIConfigGenerator(test, environment)
         host_ip = efi_gen.get_host_ip()
 
+        # Prepare artifacts directory
+        artifact_dir = ARTIFACTS_DIR / sanitize_dir_name(test_name)
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+
         if not host_ip:
             pytest.fail("Could not determine host IP address")
 
@@ -823,13 +871,12 @@ class TestNVMeBoot:
             if not vm_runner.wait_for_boot(host_ip, remaining):
                 pytest.fail(f"VM did not boot within {timeout}s")
 
+            vm_runner.collect_artifacts(host_ip, artifact_dir / "nbft.json", artifact_dir / "dmesg")
             print(f"✓ Test passed: {test_name}")
 
         finally:
-            # Collect bootlog artifact
+            # Collect artifacts
             bootlog_src = Path("host-vm") / "bootlog"
-            artifact_dir = ARTIFACTS_DIR / sanitize_dir_name(test_name)
-            artifact_dir.mkdir(parents=True, exist_ok=True)
             if bootlog_src.exists():
                 shutil.copy2(bootlog_src, artifact_dir / "bootlog")
                 print(f"✓ Bootlog saved to {artifact_dir / 'bootlog'}")

--- a/run_tests.py
+++ b/run_tests.py
@@ -951,7 +951,7 @@ Examples:
                 print(f"    - {env.get('name', 'Unnamed')}: {len(env.get('tests', []))} test(s)")
         else:
             # Run pytest
-            pytest_args = [__file__, '-v', '--tb=short', '-rF'] + pytest_args
+            pytest_args = [__file__, '-v', '--tb=short', '-s', '-rA'] + pytest_args
             sys.exit(pytest.main(pytest_args))
 
     except KeyboardInterrupt:

--- a/run_tests.py
+++ b/run_tests.py
@@ -610,25 +610,27 @@ class VMRunner:
     def wait_for_boot(self, host_ip: str, timeout: int = 120) -> bool:
         """Wait for VM to become responsive via SSH."""
         print(f"Waiting for VM to boot (timeout: {timeout}s)...")
+        vm_pings = False
+        vm_has_ssh = False
         start_time = time.time()
 
         while time.time() - start_time < timeout:
+            time.sleep(2)
+
+            # Try ping
+            if not vm_pings and self._check_ping(host_ip):
+                elapsed = int(time.time() - start_time)
+                print(f"✓ VM responds to ping (took {elapsed}s)")
+                vm_pings = True
+
             # Try SSH connection
-            if self._check_ssh(host_ip):
+            if not vm_has_ssh and self._check_ssh(host_ip):
                 elapsed = int(time.time() - start_time)
                 print(f"✓ VM is responsive via SSH (took {elapsed}s)")
+                vm_has_ssh = True
+
+            if vm_has_ssh and vm_pings:
                 return True
-
-            # Also try ping as fallback
-            if self._check_ping(host_ip):
-                # Wait a bit more for SSH to be ready
-                time.sleep(10)
-                if self._check_ssh(host_ip):
-                    elapsed = int(time.time() - start_time)
-                    print(f"✓ VM is responsive (took {elapsed}s)")
-                    return True
-
-            time.sleep(2)
 
         print(f"✗ VM did not become responsive within {timeout}s")
         return False

--- a/run_tests.py
+++ b/run_tests.py
@@ -656,12 +656,12 @@ class VMRunner:
             return False
 
     def wait_for_bootlog_entry(self, pattern: str, timeout: int = 120) -> bool:
-        """Follow the bootlog file and wait for a pattern to appear."""
+        """Follow the bootlog file and wait for a regex pattern to appear."""
         bootlog_path = self.host_vm_dir / "bootlog"
+        regex = re.compile(pattern)
         print(f"Waiting for bootlog entry: {pattern} (timeout: {timeout}s)...")
         start_time = time.time()
 
-        # Wait for the file to exist
         while not bootlog_path.exists():
             if time.time() - start_time >= timeout:
                 print(f"✗ Bootlog file never appeared within {timeout}s")
@@ -671,11 +671,12 @@ class VMRunner:
         with open(bootlog_path, 'r', errors='replace') as f:
             while time.time() - start_time < timeout:
                 line = f.readline()
-                if line:
-                    if pattern in line:
-                        elapsed = int(time.time() - start_time)
-                        print(f"✓ Found bootlog entry (took {elapsed}s): {line.rstrip()}")
-                        return True
+                if line and regex.search(line):
+                    elapsed = int(time.time() - start_time)
+                    print(f"✓ Found bootlog entry (took {elapsed}s): {line.rstrip()}")
+                    return True
+                elif line:
+                    continue
                 else:
                     time.sleep(0.5)
 
@@ -813,7 +814,7 @@ class TestNVMeBoot:
             boot_start = time.time()
 
             # Check bootlog for EFI boot success
-            efi_pattern = r"FSOpen: Open '\EFI\BOOT\' Success"
+            efi_pattern = r"FSOpen: Open '\\?EFI.*' Success"
             if not vm_runner.wait_for_bootlog_entry(efi_pattern, timeout):
                 pytest.fail("EFI boot entry not found in bootlog")
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -859,7 +859,6 @@ class TestNVMeBoot:
 
             # Start VM
             vm_runner.start_remote()
-            boot_start = time.time()
 
             # Check bootlog for EFI boot success
             efi_pattern = r"FSOpen: Open '\\?EFI.*' Success"
@@ -867,8 +866,7 @@ class TestNVMeBoot:
                 pytest.fail("EFI boot entry not found in bootlog")
 
             # Wait for boot with remaining time budget
-            remaining = max(1, timeout - int(time.time() - boot_start))
-            if not vm_runner.wait_for_boot(host_ip, remaining):
+            if not vm_runner.wait_for_boot(host_ip, timeout):
                 pytest.fail(f"VM did not boot within {timeout}s")
 
             vm_runner.collect_artifacts(host_ip, artifact_dir / "nbft.json", artifact_dir / "dmesg")

--- a/run_tests.py
+++ b/run_tests.py
@@ -9,6 +9,8 @@ and runs boot tests using pytest.
 
 import json
 import os
+import re
+import shutil
 import subprocess
 import sys
 import time
@@ -35,6 +37,15 @@ DEFAULTS = {
 
 
 SCRIPT_DIR = Path(__file__).parent
+ARTIFACTS_DIR = SCRIPT_DIR / "artifacts"
+
+
+def sanitize_dir_name(name: str) -> str:
+    """Convert a test name to a short, terminal-friendly directory name."""
+    name = name.lower()
+    name = re.sub(r'[^a-z0-9]+', '-', name)
+    name = name.strip('-')
+    return name
 
 
 def validate_schema(config: Dict[str, Any], schema_file: str) -> bool:
@@ -732,8 +743,10 @@ class TestNVMeBoot:
         test_file = os.environ.get('TEST_CONFIG_FILE', 'tests.json')
         schema_file = os.environ.get('TEST_SCHEMA_FILE', 'schemata/tests.json')
         cls.config = load_test_config(test_file, schema_file)
+        ARTIFACTS_DIR.mkdir(exist_ok=True)
         print("\n" + "="*70)
         print("NVMe/TCP Boot Test Suite")
+        print(f"Artifacts directory: {ARTIFACTS_DIR}")
         print("="*70)
 
     def test_boot(self, env_idx: int, test_idx: int):
@@ -812,6 +825,16 @@ class TestNVMeBoot:
             print(f"✓ Test passed: {test_name}")
 
         finally:
+            # Collect bootlog artifact
+            bootlog_src = Path("host-vm") / "bootlog"
+            artifact_dir = ARTIFACTS_DIR / sanitize_dir_name(test_name)
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            if bootlog_src.exists():
+                shutil.copy2(bootlog_src, artifact_dir / "bootlog")
+                print(f"✓ Bootlog saved to {artifact_dir / 'bootlog'}")
+            else:
+                print(f"Warning: bootlog not found at {bootlog_src}")
+
             # Always cleanup
             vm_runner.cleanup()
 

--- a/setup.sh
+++ b/setup.sh
@@ -42,7 +42,7 @@ install_user() {
     if [ ! -f .usr ]; then
         sudo dnf install -y vim git wget ethtool net-tools zip unzip NetworkManager \
             lorax-lmc-novirt pykickstart openssl make python3-pytest python3-jsonschema \
-            python3 python3-blessed
+            python3 python3-blessed python3-paramiko
         touch .usr
     else
         echo " : Nothing to do!"

--- a/target-vm/Makefile
+++ b/target-vm/Makefile
@@ -71,6 +71,8 @@ install: iso disks/boot.qcow2
 iso:
 	@source ../defaults.sh && export MIRROR_CENTOS MIRROR_FEDORA && python3 ../iso_selector.py
 
+# This file must be re-built every time because it depends on environment variables
+.PHONY: .build/tcp.json
 .ONESHELL: .build/tcp.json
 .build/tcp.json: tcp.json.in Makefile ../defaults.sh
 	@source ../defaults.sh

--- a/target-vm/setup-nvme-target.sh
+++ b/target-vm/setup-nvme-target.sh
@@ -43,6 +43,11 @@ cp -b tcp.json /etc/nvmet/config.json
 
 systemctl daemon-reload
 systemctl restart firewalld
-systemctl enable --now nvmet.service
+
+if systemctl is-active nvmet.service ; then
+    systemctl restart nvmet.service
+else
+    systemctl enable --now nvmet.service
+fi
 
 dmesg | grep nvmet

--- a/vm-lib/remote-netsetup.sh
+++ b/vm-lib/remote-netsetup.sh
@@ -36,13 +36,13 @@ fi
 
 if [[ -n "$IF2" && "$(nmcli conn show | grep $IF2)" == *"$IF2"* ]]; then
 	CCON="$(nmcli --get-values name,device conn | grep $IF2 | cut -d ':' -f 1)"
-	nmcli con delete "$CCON"
-	nmcli con add type ethernet con-name $IF2 ifname $IF2 ipv4.addresses $IP2 ipv4.method manual ipv6.method shared
-	nmcli con up "$IF2"
+	nmcli dev connect "$IF2"
+	nmcli con modify $CCON ipv4.addresses $IP2 ipv4.method manual ipv6.method shared connection.autoconnect yes
+	nmcli dev reapply "$IF2"
 elif [[ -n "$IF2" ]] ; then
 	CONN2="$(nmcli dev status | grep $IF2)"
 	if [[ "$CONN2" == *"$IF2"* ]]; then
-			nmcli con add type ethernet con-name $IF2 ifname $IF2 ipv4.addresses $IP2 ipv4.method manual ipv6.method shared
+			nmcli con add type ethernet con-name $IF2 ifname $IF2 ipv4.addresses $IP2 ipv4.method manual ipv6.method shared connection.autoconnect yes
 			nmcli con up "$IF2"
 	else
 			echo "$IF2 not found"
@@ -52,13 +52,13 @@ fi
 
 if [[ -n "$IF3" && "$(nmcli conn show | grep $IF3)" == *"$IF3"* ]]; then
 	CCON="$(nmcli --get-values name,device conn | grep $IF3 | cut -d ':' -f 1)"
-	nmcli con delete "$CCON"
-	nmcli con add type ethernet con-name $IF3 ifname $IF3 ipv4.addresses $IP3 ipv4.method manual ipv6.method shared
-	nmcli con up "$IF3"
+	nmcli dev connect "$IF3"
+	nmcli con modify $CCON ipv4.addresses $IP3 ipv4.method manual ipv6.method shared connection.autoconnect yes
+	nmcli dev reapply "$IF3"
 elif [[ -n "$IF3" ]] ; then
 	CONN2="$(nmcli dev status | grep $IF3)"
 	if [[ "$CONN2" == *"$IF3"* ]]; then
-		nmcli con add type ethernet con-name $IF3 ifname $IF3 ipv4.addresses $IP3 ipv4.method manual ipv6.method shared
+		nmcli con add type ethernet con-name $IF3 ifname $IF3 ipv4.addresses $IP3 ipv4.method manual ipv6.method shared connection.autoconnect yes
 		nmcli con up "$IF3"
 	else
 		echo "$IF3 not found"


### PR DESCRIPTION
This patch series introduces a few bug fixes, but most importantly the collection of these test artifacts:
- EDK2 boot log
- NBFT (if the boot is successful)
- `dmesg` log (if the boot is successful)

The artifacts are stored in the `artifacts` directory in subdirectories named after the test case itself. If they are not overwritten, they persist until manual deletion by the system user.