### PR TITLE
`setup.sh net` cleanup and improvements 

### DIFF
--- a/host-vm/netsetup.sh
+++ b/host-vm/netsetup.sh
@@ -44,7 +44,7 @@ for arg in "$@"; do
 done
 
 if [ -z "$HOST_IP1" ]; then
-    if [ -n "$(get_bridge_slaves ${BRIDGE0_NAME})" ]; then
+    if [ -n "$(get_bridge_slaves ${BRIDGE0_NAME} 2>/dev/null)" ]; then
         read -rp "Enter the IP address of $VMNAME on $BRIDGE0_NAME: " HOST_IP1
         if [ -z "$HOST_IP1" ]; then
             echo -e "${RED}Error: IP address is required in bridged mode${NC}" >&2

--- a/host-vm/netsetup.sh
+++ b/host-vm/netsetup.sh
@@ -7,6 +7,8 @@ set -e
 DIR="$(dirname -- "$(realpath -- "$0")")"
 VMNAME=$(basename $PWD)
 
+. $DIR/../defaults.sh
+. $DIR/../vm-lib/common.sh
 . $DIR/../vm-lib/colors.sh
 
 show-help() {
@@ -40,7 +42,18 @@ for arg in "$@"; do
         *) HOST_IP1="$arg"; break ;;
     esac
 done
-HOST_IP1="${HOST_IP1:-localhost}"
+
+if [ -z "$HOST_IP1" ]; then
+    if [ -n "$(get_bridge_slaves ${BRIDGE0_NAME})" ]; then
+        read -rp "Enter the IP address of $VMNAME on $BRIDGE0_NAME: " HOST_IP1
+        if [ -z "$HOST_IP1" ]; then
+            echo -e "${RED}Error: IP address is required in bridged mode${NC}" >&2
+            exit 1
+        fi
+    else
+        HOST_IP1="localhost"
+    fi
+fi
 
 if [ "$GEN_NQN" -eq 1 ]; then
     export HOSTNQN="nqn.2014-08.org.nvmexpress:uuid:$(uuidgen)"

--- a/host-vm/vm.sh
+++ b/host-vm/vm.sh
@@ -141,7 +141,7 @@ QARGS="$@"
 check_qemu_command
 
 # Setup network configuration based on the effective network setup
-if [ -n "$(get_bridge_slaves ${BRIDGE0_NAME})" ] ; then
+if [ -n "$(get_bridge_slaves ${BRIDGE0_NAME} 2>/dev/null)" ] ; then
         NET0_NET="-netdev bridge,br=$BRIDGE0_NAME,id=net0,helper=$BRIDGE_HELPER"
         NET0_DEV="-device e1000e,netdev=net0,mac=$HOST_MAC1,addr=4"
 else

--- a/iso_selector.py
+++ b/iso_selector.py
@@ -139,8 +139,8 @@ def _resolve_fedora(version=None):
 CHOICES = [
     ("CentOS Stream 10",          lambda: _resolve_direct("MIRROR_CENTOS")),
     ("Fedora (latest)",            lambda: _resolve_fedora()),
+    ("Fedora 44",                  lambda: _resolve_fedora(44)),
     ("Fedora 43",                  lambda: _resolve_fedora(43)),
-    ("Fedora 42",                  lambda: _resolve_fedora(42)),
     ("Custom ISO download link",   None),
 ]
 

--- a/setup.sh
+++ b/setup.sh
@@ -134,9 +134,9 @@ install_network() {
 
     source $DIR/vm-lib/common.sh
 
-    bridge_iface "$BRIDGE0_NAME" "$1" "$2"
+    bridge_iface --optional "$BRIDGE0_NAME" "$1" "$2"
 
-    ip -h -c -o -br address show ${BRIDGE0_NAME}
+    ip -h -c -o -br address show ${BRIDGE0_NAME} 2>/dev/null || true
 
     if ! nmcli dev show "$BRIDGE1_NAME" &>/dev/null ; then
 	    bridge_iface "$BRIDGE1_NAME" "$3" "$4"

--- a/target-vm/Makefile
+++ b/target-vm/Makefile
@@ -36,7 +36,6 @@ help:
 	@echo "Disk creation targets:"
 	@echo "  disks/boot.qcow2      Create an empty boot disk image ($(DRIVE_CAP))"
 	@echo "  disks/nvme1.qcow2     Create an empty NVMe disk image ($(DRIVE_CAP))"
-	@echo "  disks/rh-boot.qcow2   Build a pre-installed disk image using livemedia-creator (Red Hat distros only)"
 	@echo "  boot.iso              Create a custom ISO with the embedded Kickstart config"
 	@echo ""
 	@echo "Configuration variables:"
@@ -56,14 +55,11 @@ help:
 .PHONY: auto-start
 .ONESHELL: auto-start
 auto-start: disks/nvme1.qcow2 $(SETUP_SCRIPT)
-# disks/rh-boot.qcow2 is not an explicit dependency because it consumes
-# .build/rh-boot.qcow2 for its creation. This, however, confuses GNU Make
-# to go rebuild the qcow2 disk unnecessarily.
-	[ -f disks/rh-boot.qcow2 ] || make auto-install || exit 1
-	@bash ./$(SETUP_SCRIPT) start disks/rh-boot.qcow2 $(_DISPLAY_ARGS) -n $(EXTRA_DRIVES) -- $(QEMU_ARGS)
+	[ -f disks/boot.qcow2 ] || make auto-install || exit 1
+	@bash ./$(SETUP_SCRIPT) start disks/boot.qcow2 $(_DISPLAY_ARGS) -n $(EXTRA_DRIVES) -- $(QEMU_ARGS)
 
 .PHONY: auto-install
-auto-install: disks/rh-boot.qcow2 boot.iso $(SETUP_SCRIPT)
+auto-install: disks/boot.qcow2 boot.iso $(SETUP_SCRIPT)
 	@source ../vm-lib/colors.sh && echo -e "$${RED}The VM is installing. Do not interrupt!$${NC}"
 	@bash ./$(SETUP_SCRIPT) install $< -F -i boot.iso -- $(QEMU_ARGS)
 
@@ -148,7 +144,7 @@ wipe:
 
 .PHONY: clean
 clean:
-	-rm -f disks/rh-boot.qcow2 disks/boot.qcow2
+	-rm -f disks/boot.qcow2
 	-rm -f boot.iso
 	-rm -f *.log
 	-rm -rf .build

--- a/target-vm/netsetup.sh
+++ b/target-vm/netsetup.sh
@@ -7,6 +7,8 @@ set -e
 DIR="$(dirname -- "$(realpath -- "$0")")"
 VMNAME=$(basename $PWD)
 
+. $DIR/../defaults.sh
+. $DIR/../vm-lib/common.sh
 . $DIR/../vm-lib/colors.sh
 
 show-help() {
@@ -43,7 +45,18 @@ for arg in "$@"; do
         *) TARGET_IP1="$arg"; break ;;
     esac
 done
-TARGET_IP1="${TARGET_IP1:-localhost}"
+
+if [ -z "$TARGET_IP1" ]; then
+    if [ -n "$(get_bridge_slaves ${BRIDGE0_NAME})" ]; then
+        read -rp "Enter the IP address of $VMNAME on $BRIDGE0_NAME: " TARGET_IP1
+        if [ -z "$TARGET_IP1" ]; then
+            echo -e "${RED}Error: IP address is required in bridged mode${NC}" >&2
+            exit 1
+        fi
+    else
+        TARGET_IP1="localhost"
+    fi
+fi
 
 if [ "$NEW_SUBNQN" -eq 1 ]; then
     export SUBNQN="nqn.2014-08.org.nvmexpress:uuid:$(uuidgen)"

--- a/target-vm/netsetup.sh
+++ b/target-vm/netsetup.sh
@@ -47,7 +47,7 @@ for arg in "$@"; do
 done
 
 if [ -z "$TARGET_IP1" ]; then
-    if [ -n "$(get_bridge_slaves ${BRIDGE0_NAME})" ]; then
+    if [ -n "$(get_bridge_slaves ${BRIDGE0_NAME} 2>/dev/null)" ]; then
         read -rp "Enter the IP address of $VMNAME on $BRIDGE0_NAME: " TARGET_IP1
         if [ -z "$TARGET_IP1" ]; then
             echo -e "${RED}Error: IP address is required in bridged mode${NC}" >&2

--- a/target-vm/vm.sh
+++ b/target-vm/vm.sh
@@ -147,7 +147,7 @@ else
 fi
 
 # Detect a bridged setup
-if [ -n "$(get_bridge_slaves ${BRIDGE0_NAME})" ] ; then
+if [ -n "$(get_bridge_slaves ${BRIDGE0_NAME} 2>/dev/null)" ] ; then
         NET0_NET="-netdev bridge,br=$BRIDGE0_NAME,id=net0,helper=$BRIDGE_HELPER"
         NET0_DEV="-device virtio-net-pci,netdev=net0,mac=$TARGET_MAC1,addr=4"
 else

--- a/teardown.sh
+++ b/teardown.sh
@@ -54,7 +54,7 @@ revert_bridge_iface() {
 		local slave_conns=($(nmcli -t -f NAME,DEVICE,SLAVE con show | grep ":${slave}:bridge$" | cut -d: -f1))
 		# Check all connections
 		while IFS= read -r conn ; do
-			if ! [ ${slave} = $(nmcli -g connection.interface-name con show "$conn") ] ; then
+			if ! [ "${slave}" = "$(nmcli -g connection.interface-name con show "$conn")" ] ; then
 				continue
 			elif ! printf '%s\0' "${slave_conns[@]}" | grep -F -x -z -- "$conn" &>/dev/null ; then
 				# Switch to the old non-bridged connection

--- a/vm-lib/common.sh
+++ b/vm-lib/common.sh
@@ -353,6 +353,9 @@ EOF
         fi
     fi
 
+    # Capture existing IP before the interface is brought down
+    local _existing_ip=""
+
     # Create bridge based on whether it's none or bridged
     if [[ "$netdev" == *"none"* ]]; then
         echo " : local - skipping bridged network setup"
@@ -366,6 +369,13 @@ EOF
         # ip link set $netdev promisc on
 
         local MAC=$(nmcli -t -f general.hwaddr -e yes dev show $netdev | sed 's/^GENERAL.HWADDR://')
+        local _ip_method
+        _ip_method=$(nmcli -t -f ipv4.method con show "$(nmcli -t -f GENERAL.CONNECTION dev show "$netdev" | cut -d: -f2)" 2>/dev/null)
+        if [[ "$_ip_method" == *"manual"* ]]; then
+            _existing_ip=$(ip -4 -o addr show dev "$netdev" 2>/dev/null | awk '{print $4}' | head -1)
+	elif [[ "$_ip_method" == *"auto"* ]]; then
+            _existing_ip="dhcp"
+        fi
         local br_conn="${br_name}"
         sudo nmcli dev down $netdev || true
         sudo nmcli con add type bridge ifname ${br_name} con-name ${br_name} autoconnect yes stp off ethernet.cloned-mac-address $MAC
@@ -374,15 +384,19 @@ EOF
         sudo nmcli con up bridge-slave-${netdev}
     fi
 
-    # Determine default IP address based on bridge name
-    case ${br_name} in
-        "$BRIDGE1_NAME")
-            local ip_addr_default=$HOSTGW_CIDR2;;
-        "$BRIDGE2_NAME")
-            local ip_addr_default=$HOSTGW_CIDR3;;
-        *)
-            local ip_addr_default='dhcp';;
-    esac
+    # Determine default IP address: prefer the slave NIC's existing IP
+    if [ -n "$_existing_ip" ]; then
+        local ip_addr_default="$_existing_ip"
+    else
+        case ${br_name} in
+            "$BRIDGE1_NAME")
+                local ip_addr_default=$HOSTGW_CIDR2;;
+            "$BRIDGE2_NAME")
+                local ip_addr_default=$HOSTGW_CIDR3;;
+            *)
+                local ip_addr_default='dhcp';;
+        esac
+    fi
 
     # Interactive prompt for IP address if not provided
     if [ -z "$ip_addr" ]; then

--- a/vm-lib/common.sh
+++ b/vm-lib/common.sh
@@ -343,7 +343,7 @@ EOF
 
     # Interactive prompt for network device if not provided
     if [ -z "$netdev" ]; then
-        nmcli dev status
+        ip -br addr show
         echo ""
         read -r -p "Enter name of the network interface to bridge with ${br_name} or \"none\" to skip configuration: " netdev
 

--- a/vm-lib/common.sh
+++ b/vm-lib/common.sh
@@ -285,16 +285,17 @@ resolve_display_mode() {
 }
 
 bridge_iface() {
-    # Parse arguments and check for help
     local br_name=""
     local netdev=""
     local ip_addr=""
+    local _optional=false
 
-    # Check if help is requested
-    for arg in "$@"; do
-        if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
-            cat <<EOF
-Usage: bridge_iface BRIDGE_NAME [SLAVE_INTERFACE] [IP_ADDRESS]
+    # Parse flags
+    while [[ "${1:-}" == -* ]]; do
+        case "$1" in
+            -h|--help)
+                cat <<EOF
+Usage: bridge_iface [--optional] BRIDGE_NAME [SLAVE_INTERFACE] [IP_ADDRESS]
 
 Configure a network bridge using NetworkManager.
 
@@ -309,19 +310,31 @@ Arguments:
                     - Default for br2: $HOSTGW_CIDR3
                     - Default for others: dhcp
 
+Options:
+  --optional        Skip bridge creation entirely when the slave interface
+                    is 'none' (instead of creating a bridge without a slave)
+  -h, --help        Show this help message
+
 Examples:
   bridge_iface $BRIDGE0_NAME eth0 192.168.1.1/24
+  bridge_iface --optional $BRIDGE0_NAME eth0     # skip if user says 'none'
   bridge_iface br1 none dhcp
   bridge_iface br2 enp2s0
-  bridge_iface $BRIDGE0_NAME                    # Interactive mode
-
-Options:
-  -h, --help        Show this help message
+  bridge_iface $BRIDGE0_NAME                     # Interactive mode
 
 Note: If the bridge already exists, this function will skip configuration.
 EOF
-            return 0
-        fi
+                return 0
+                ;;
+            --optional)
+                _optional=true
+                shift
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                return 1
+                ;;
+        esac
     done
 
     # Parse positional arguments
@@ -358,6 +371,10 @@ EOF
 
     # Create bridge based on whether it's none or bridged
     if [[ "$netdev" == *"none"* ]]; then
+        if $_optional; then
+            echo " : ${br_name} - skipping optional bridge (no device specified)"
+            return 0
+        fi
         echo " : local - skipping bridged network setup"
         sudo nmcli conn add type bridge ifname ${br_name} con-name ${br_name} stp yes autoconnect yes
         local br_conn=${br_name}
@@ -431,4 +448,5 @@ EOF
 get_bridge_slaves() {
         local br_name="$1"
         ip -o link show master "$br_name" | cut -d: -f2 | sed -e 's/^ *//'
+        return 0
 }


### PR DESCRIPTION
Major changes:
- the `setup.sh net` subcommand now respects the existing network configuration of the interface chosen to bridge to
- `netsetup.sh` scripts now prompt for missing IP addresses 
- deprecated the option to have two boot disks for the `target-vm`---only one remains, but there are still two OS installation methods: manual and Anaconda Kickstart
- Fedora 44 option added into the OS selection menu (tested and working OK)